### PR TITLE
Phase 10: Complete Whitespace Control Implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Group 10: Whitespace Control** - Complete implementation
+  - **Task 10.1: Trim Token Parser** - Complete trim detection for expressions and tags
+    - Expression trim parsing: `{{-`, `-}}`, `{{-` `-}}`
+    - Tag trim parsing: `{%-`, `-%}`, `{%-` `-%}` 
+    - Support for left trim, right trim, and both trim combinations
+    - Integration with existing expression and tag parsing infrastructure
+  - **Task 10.2: AST Trim Options** - Complete trim option integration
+    - `trim_left` and `trim_right` options added to AST node structures
+    - All expression and tag builder functions support trim options
+    - Maintains unified AST structure convention `{type, parts, opts}`
+  - **Task 10.3: Whitespace Processor** - Complete trim logic implementation  
+    - `Mau.WhitespaceProcessor` module for whitespace control
+    - Trims adjacent text nodes based on trim options
+    - Handles left trim (trailing whitespace removal) and right trim (leading whitespace removal)
+    - Supports complex whitespace including newlines, tabs, and multiple spaces
+    - Graceful handling of empty text nodes and non-text adjacent nodes
+  - **Task 10.4: Pipeline Integration** - Complete rendering pipeline integration
+    - Whitespace processing integrated into main `Mau.render/3` function
+    - Applied before block processing to preserve trim information from individual tags
+    - Works seamlessly with expressions, tags, conditionals, and loops
+    - Zero performance impact when no trim options are used
+
+### Technical Details
+- Extended parser with trim token detection using NimbleParsec choice combinators
+- Expression trim AST nodes: `{:expression, [...], [trim_left: true, trim_right: true]}`
+- Tag trim AST nodes: `{:tag, [...], [trim_left: true, trim_right: true]}`
+- Whitespace processor applies `String.trim_trailing/1` and `String.trim_leading/1` to adjacent text nodes
+- Integrated before block processing to handle individual tag trim options correctly
+- Maintains backward compatibility - templates without trim tokens work unchanged
+
+### Testing
+- All tests pass (472 tests: 56 doctests + 416 unit tests)
+- New whitespace parser test suite (12 comprehensive parsing tests)
+- New whitespace processor test suite (11 whitespace logic tests including 1 doctest)
+- New whitespace integration test suite (13 end-to-end scenarios)
+- Comprehensive trim token parsing with all combinations (left, right, both, none)
+- Full template rendering with whitespace control for expressions, tags, conditionals, and loops
+- Complex whitespace handling tests including newlines, tabs, and mixed content
+
+### Added
 - **Group 9: Loop Tags** - Complete implementation
   - **Task 9.1: For Tag Parser** - Complete for tag parsing with loop variable and collection expressions
     - `for` tag combinator parsing with `{%` and `%}` delimiters

--- a/TASKS.md
+++ b/TASKS.md
@@ -381,29 +381,34 @@
 
 ---
 
-## Group 10: Whitespace Control
+## Group 10: Whitespace Control ✅ COMPLETED
 
-### Task 10.1: Trim Token Parser
-- [ ] Add trim detection to expression delimiters
-- [ ] Parse `{{-` and `-}}` variants
-- [ ] Parse `{%-` and `-%}` variants
-- [ ] Write tests for trim token parsing
+### Task 10.1: Trim Token Parser ✅
+- [x] Add trim detection to expression delimiters (`{{-`, `-}}`)
+- [x] Parse `{{-` and `-}}` variants for left and right trim
+- [x] Parse `{%-` and `-%}` variants for tag trim
+- [x] Write tests for trim token parsing (12 comprehensive tests)
 
-### Task 10.2: Trim Options in AST
-- [ ] Add `trim_left` and `trim_right` to AST options
-- [ ] Update all expression and tag node builders
-- [ ] Write tests for trim options in AST
+### Task 10.2: Trim Options in AST ✅
+- [x] Add `trim_left` and `trim_right` to AST options
+- [x] Update all expression and tag node builder functions
+- [x] Maintain unified AST structure convention
+- [x] Write tests for trim options in AST nodes
 
-### Task 10.3: Whitespace Processor
-- [ ] Create `apply_whitespace_control/1` function
-- [ ] Implement trim logic for adjacent text nodes
-- [ ] Handle complex trim scenarios
-- [ ] Write tests for whitespace processing
+### Task 10.3: Whitespace Processor ✅
+- [x] Create `Mau.WhitespaceProcessor` module
+- [x] Implement `apply_whitespace_control/1` function
+- [x] Implement trim logic for adjacent text nodes
+- [x] Handle complex trim scenarios (newlines, tabs, multiple spaces)
+- [x] Handle edge cases (empty nodes, non-text adjacent nodes)
+- [x] Write tests for whitespace processing (11 comprehensive tests)
 
-### Task 10.4: Trim Integration
-- [ ] Add whitespace processing to main rendering pipeline
-- [ ] Ensure trim works with all expression and tag types
-- [ ] Write comprehensive whitespace control tests
+### Task 10.4: Trim Integration ✅
+- [x] Add whitespace processing to main rendering pipeline
+- [x] Integrate before block processing to preserve tag trim options
+- [x] Ensure trim works with all expression and tag types
+- [x] Write comprehensive whitespace control tests (13 integration scenarios)
+- [x] Verify compatibility with conditionals, loops, and all existing features
 
 ---
 

--- a/lib/mau.ex
+++ b/lib/mau.ex
@@ -11,6 +11,7 @@ defmodule Mau do
   alias Mau.Parser
   alias Mau.Renderer
   alias Mau.BlockProcessor
+  alias Mau.WhitespaceProcessor
 
   @doc """
   Compiles a template string into an AST.
@@ -52,7 +53,8 @@ defmodule Mau do
 
   def render(template, context, _opts) when is_binary(template) and is_map(context) do
     with {:ok, ast} <- Parser.parse(template),
-         processed_ast <- BlockProcessor.process_blocks(ast),
+         trimmed_ast <- WhitespaceProcessor.apply_whitespace_control(ast),
+         processed_ast <- BlockProcessor.process_blocks(trimmed_ast),
          {:ok, result} <- Renderer.render(processed_ast, context) do
       {:ok, result}
     end

--- a/lib/mau/whitespace_processor.ex
+++ b/lib/mau/whitespace_processor.ex
@@ -1,0 +1,103 @@
+defmodule Mau.WhitespaceProcessor do
+  @moduledoc """
+  Processes template AST to apply whitespace control based on trim options.
+  
+  This module takes an AST with trim options and applies whitespace trimming
+  logic to adjacent text nodes.
+  """
+
+  @doc """
+  Applies whitespace control to an AST based on trim options.
+  
+  Trims whitespace from adjacent text nodes when expressions or tags
+  have trim_left or trim_right options set.
+  
+  ## Examples
+  
+      iex> nodes = [
+      ...>   {:text, ["  before  "], []},
+      ...>   {:expression, [{:variable, ["name"], []}], [trim_left: true]},
+      ...>   {:text, ["  after  "], []}
+      ...> ]
+      iex> Mau.WhitespaceProcessor.apply_whitespace_control(nodes)
+      [
+        {:text, ["  before"], []},
+        {:expression, [{:variable, ["name"], []}], [trim_left: true]},
+        {:text, ["  after  "], []}
+      ]
+  """
+  def apply_whitespace_control(nodes) when is_list(nodes) do
+    apply_trim_processing(nodes, [])
+  end
+
+  # Main processing loop
+  defp apply_trim_processing([], acc) do
+    Enum.reverse(acc)
+  end
+
+  defp apply_trim_processing([node | rest], acc) do
+    case should_trim_node(node) do
+      {true, trim_options} ->
+        # Apply trimming to adjacent text nodes
+        {updated_acc, updated_rest} = apply_trim_to_adjacent(acc, rest, trim_options)
+        apply_trim_processing(updated_rest, [node | updated_acc])
+      
+      {false, _} ->
+        # No trimming needed
+        apply_trim_processing(rest, [node | acc])
+    end
+  end
+
+  # Check if a node needs trimming applied
+  defp should_trim_node({_type, _parts, opts}) do
+    trim_left = Keyword.get(opts, :trim_left, false)
+    trim_right = Keyword.get(opts, :trim_right, false)
+    
+    if trim_left || trim_right do
+      {true, %{trim_left: trim_left, trim_right: trim_right}}
+    else
+      {false, nil}
+    end
+  end
+
+  # Apply trimming to adjacent text nodes
+  defp apply_trim_to_adjacent(acc, rest, trim_options) do
+    updated_acc = if trim_options.trim_left do
+      trim_left_whitespace(acc)
+    else
+      acc
+    end
+    
+    updated_rest = if trim_options.trim_right do
+      trim_right_whitespace(rest)
+    else
+      rest
+    end
+    
+    {updated_acc, updated_rest}
+  end
+
+  # Trim whitespace from the right side of the last text node in accumulator
+  defp trim_left_whitespace([{:text, [content], opts} | rest_acc]) do
+    trimmed_content = String.trim_trailing(content)
+    updated_node = {:text, [trimmed_content], opts}
+    [updated_node | rest_acc]
+  end
+
+  defp trim_left_whitespace(acc) do
+    # No text node to trim or not a text node at the end
+    acc
+  end
+
+  # Trim whitespace from the left side of the first text node in remaining nodes
+  defp trim_right_whitespace([{:text, [content], opts} | rest]) do
+    trimmed_content = String.trim_leading(content)
+    updated_node = {:text, [trimmed_content], opts}
+    [updated_node | rest]
+  end
+
+  defp trim_right_whitespace(rest) do
+    # No text node to trim or not a text node at the beginning
+    rest
+  end
+end

--- a/test/mau/whitespace_integration_test.exs
+++ b/test/mau/whitespace_integration_test.exs
@@ -1,0 +1,149 @@
+defmodule Mau.WhitespaceIntegrationTest do
+  use ExUnit.Case, async: true
+  alias Mau
+
+  describe "whitespace control integration" do
+    test "trims whitespace with left trim expression" do
+      template = """
+      Hello   {{- name }}   World
+      """
+      context = %{"name" => "Alice"}
+      
+      assert {:ok, result} = Mau.render(template, context)
+      # Left trim should remove trailing whitespace before the expression
+      assert result == "HelloAlice   World\n"
+    end
+
+    test "trims whitespace with right trim expression" do
+      template = """
+      Hello   {{ name -}}   World
+      """
+      context = %{"name" => "Alice"}
+      
+      assert {:ok, result} = Mau.render(template, context)
+      # Right trim should remove leading whitespace after the expression
+      assert result == "Hello   AliceWorld\n"
+    end
+
+    test "trims whitespace with both trim expression" do
+      template = """
+      Hello   {{- name -}}   World
+      """
+      context = %{"name" => "Alice"}
+      
+      assert {:ok, result} = Mau.render(template, context)
+      # Both trim should remove whitespace on both sides
+      assert result == "HelloAliceWorld\n"
+    end
+
+    test "trims whitespace with left trim tag" do
+      template = """
+      Hello   {%- assign greeting = "Hi" %}   World
+      """
+      context = %{}
+      
+      assert {:ok, result} = Mau.render(template, context)
+      # Left trim should remove trailing whitespace before the tag
+      assert result == "Hello   World\n"
+    end
+
+    test "trims whitespace with right trim tag" do
+      template = """
+      Hello   {% assign greeting = "Hi" -%}   World
+      """
+      context = %{}
+      
+      assert {:ok, result} = Mau.render(template, context)
+      # Right trim should remove leading whitespace after the tag
+      assert result == "Hello   World\n"
+    end
+
+    test "trims whitespace with both trim tag" do
+      template = """
+      Hello   {%- assign greeting = "Hi" -%}   World
+      """
+      context = %{}
+      
+      assert {:ok, result} = Mau.render(template, context)
+      # Both trim should remove whitespace on both sides
+      assert result == "HelloWorld\n"
+    end
+
+    test "handles multiple trim expressions in sequence" do
+      template = """
+      Start   {{- first -}}   Middle   {{- second -}}   End
+      """
+      context = %{"first" => "A", "second" => "B"}
+      
+      assert {:ok, result} = Mau.render(template, context)
+      # Should trim around each expression
+      assert result == "StartAMiddleBEnd\n"
+    end
+
+    test "handles trim in conditional blocks" do
+      template = """
+      Before   {%- if true -%}   Inside   {%- endif -%}   After
+      """
+      context = %{}
+      
+      assert {:ok, result} = Mau.render(template, context)
+      # Should trim around the conditional block tags
+      assert result == "BeforeInsideAfter\n"
+    end
+
+    test "handles trim in loop blocks" do
+      template = """
+      Start   {%- for item in items -%}{{ item }}{%- endfor -%}   End
+      """
+      context = %{"items" => ["A", "B", "C"]}
+      
+      assert {:ok, result} = Mau.render(template, context)
+      # Should trim around the loop block
+      assert result == "StartABCEnd\n"
+    end
+
+    test "preserves content when no trim is specified" do
+      template = """
+      Hello   {{ name }}   World
+      """
+      context = %{"name" => "Alice"}
+      
+      assert {:ok, result} = Mau.render(template, context)
+      # Should preserve all whitespace when no trim is specified
+      assert result == "Hello   Alice   World\n"
+    end
+
+    test "handles mixed trim and non-trim elements" do
+      template = """
+      A   {{- one }}   B   {{ two -}}   C   {{- three -}}   D
+      """
+      context = %{"one" => "1", "two" => "2", "three" => "3"}
+      
+      assert {:ok, result} = Mau.render(template, context)
+      # Should apply different trim behaviors correctly
+      assert result == "A1   B   2C3D\n"
+    end
+
+    test "handles newlines and complex whitespace" do
+      template = """
+      Line 1
+        {{- indented }}
+      Line 2
+      """
+      context = %{"indented" => "CONTENT"}
+      
+      assert {:ok, result} = Mau.render(template, context)
+      # Should trim the newline and indentation before the expression
+      assert result == "Line 1CONTENT\nLine 2\n"
+    end
+
+    test "handles empty result after trimming" do
+      template = "   {{- empty -}}   "
+      context = %{"empty" => ""}
+      
+      assert {:ok, result} = Mau.render(template, context)
+      # Should result in empty string after trimming both sides
+      assert result == ""
+    end
+  end
+end

--- a/test/mau/whitespace_parser_test.exs
+++ b/test/mau/whitespace_parser_test.exs
@@ -1,0 +1,144 @@
+defmodule Mau.WhitespaceParserTest do
+  use ExUnit.Case, async: true
+  alias Mau.Parser
+
+  describe "expression trim token parsing" do
+    test "parses normal expression without trim" do
+      result = Parser.parse("{{ name }}")
+      
+      assert {:ok, nodes} = result
+      assert [node] = nodes
+      assert {:expression, [_], opts} = node
+      assert Keyword.get(opts, :trim_left) == nil
+      assert Keyword.get(opts, :trim_right) == nil
+    end
+
+    test "parses expression with left trim" do
+      result = Parser.parse("{{- name }}")
+      
+      assert {:ok, nodes} = result
+      assert [node] = nodes
+      assert {:expression, [_], opts} = node
+      assert Keyword.get(opts, :trim_left) == true
+      assert Keyword.get(opts, :trim_right) == nil
+    end
+
+    test "parses expression with right trim" do
+      result = Parser.parse("{{ name -}}")
+      
+      assert {:ok, nodes} = result
+      assert [node] = nodes
+      assert {:expression, [_], opts} = node
+      assert Keyword.get(opts, :trim_left) == nil
+      assert Keyword.get(opts, :trim_right) == true
+    end
+
+    test "parses expression with both trim" do
+      result = Parser.parse("{{- name -}}")
+      
+      assert {:ok, nodes} = result
+      assert [node] = nodes
+      assert {:expression, [_], opts} = node
+      assert Keyword.get(opts, :trim_left) == true
+      assert Keyword.get(opts, :trim_right) == true
+    end
+
+    test "parses complex expression with trim" do
+      result = Parser.parse("{{- user.name | upper_case -}}")
+      
+      assert {:ok, nodes} = result
+      assert [node] = nodes
+      assert {:expression, [_], opts} = node
+      assert Keyword.get(opts, :trim_left) == true
+      assert Keyword.get(opts, :trim_right) == true
+    end
+  end
+
+  describe "tag trim token parsing" do
+    test "parses normal tag without trim" do
+      result = Parser.parse("{% assign name = \"value\" %}")
+      
+      assert {:ok, nodes} = result
+      assert [node] = nodes
+      assert {:tag, [:assign, _, _], opts} = node
+      assert Keyword.get(opts, :trim_left) == nil
+      assert Keyword.get(opts, :trim_right) == nil
+    end
+
+    test "parses tag with left trim" do
+      result = Parser.parse("{%- assign name = \"value\" %}")
+      
+      assert {:ok, nodes} = result
+      assert [node] = nodes
+      assert {:tag, [:assign, _, _], opts} = node
+      assert Keyword.get(opts, :trim_left) == true
+      assert Keyword.get(opts, :trim_right) == nil
+    end
+
+    test "parses tag with right trim" do
+      result = Parser.parse("{% assign name = \"value\" -%}")
+      
+      assert {:ok, nodes} = result
+      assert [node] = nodes
+      assert {:tag, [:assign, _, _], opts} = node
+      assert Keyword.get(opts, :trim_left) == nil
+      assert Keyword.get(opts, :trim_right) == true
+    end
+
+    test "parses tag with both trim" do
+      result = Parser.parse("{%- assign name = \"value\" -%}")
+      
+      assert {:ok, nodes} = result
+      assert [node] = nodes
+      assert {:tag, [:assign, _, _], opts} = node
+      assert Keyword.get(opts, :trim_left) == true
+      assert Keyword.get(opts, :trim_right) == true
+    end
+
+    test "parses conditional tags with trim" do
+      result = Parser.parse("{%- if condition -%}")
+      
+      assert {:ok, nodes} = result
+      assert [node] = nodes
+      assert {:tag, [:if, _], opts} = node
+      assert Keyword.get(opts, :trim_left) == true
+      assert Keyword.get(opts, :trim_right) == true
+    end
+
+    test "parses loop tags with trim" do
+      result = Parser.parse("{%- for item in items -%}")
+      
+      assert {:ok, nodes} = result
+      assert [node] = nodes
+      assert {:tag, [:for, _, _], opts} = node
+      assert Keyword.get(opts, :trim_left) == true
+      assert Keyword.get(opts, :trim_right) == true
+    end
+  end
+
+  describe "mixed content with trim tokens" do
+    test "parses mixed content with various trim combinations" do
+      template = """
+      Start  {{- name }}  Middle  {{ value -}}  End
+      """
+      
+      result = Parser.parse(template)
+      assert {:ok, nodes} = result
+      
+      # Should have: text, expression(left_trim), text, expression(right_trim), text
+      assert length(nodes) == 5
+      
+      [text1, expr1, text2, expr2, text3] = nodes
+      
+      assert {:text, ["Start  "], []} = text1
+      assert {:expression, [_], opts1} = expr1
+      assert Keyword.get(opts1, :trim_left) == true
+      
+      assert {:text, ["  Middle  "], []} = text2
+      assert {:expression, [_], opts2} = expr2
+      assert Keyword.get(opts2, :trim_right) == true
+      
+      assert {:text, ["  End\n"], []} = text3
+    end
+  end
+end

--- a/test/mau/whitespace_processor_test.exs
+++ b/test/mau/whitespace_processor_test.exs
@@ -1,0 +1,172 @@
+defmodule Mau.WhitespaceProcessorTest do
+  use ExUnit.Case, async: true
+  alias Mau.WhitespaceProcessor
+  doctest Mau.WhitespaceProcessor
+
+  describe "apply_whitespace_control/1" do
+    test "leaves nodes without trim options unchanged" do
+      nodes = [
+        {:text, ["  before  "], []},
+        {:expression, [{:variable, ["name"], []}], []},
+        {:text, ["  after  "], []}
+      ]
+      
+      result = WhitespaceProcessor.apply_whitespace_control(nodes)
+      assert result == nodes
+    end
+
+    test "trims left whitespace from preceding text node" do
+      nodes = [
+        {:text, ["  before  "], []},
+        {:expression, [{:variable, ["name"], []}], [trim_left: true]},
+        {:text, ["  after  "], []}
+      ]
+      
+      result = WhitespaceProcessor.apply_whitespace_control(nodes)
+      
+      expected = [
+        {:text, ["  before"], []},
+        {:expression, [{:variable, ["name"], []}], [trim_left: true]},
+        {:text, ["  after  "], []}
+      ]
+      
+      assert result == expected
+    end
+
+    test "trims right whitespace from following text node" do
+      nodes = [
+        {:text, ["  before  "], []},
+        {:expression, [{:variable, ["name"], []}], [trim_right: true]},
+        {:text, ["  after  "], []}
+      ]
+      
+      result = WhitespaceProcessor.apply_whitespace_control(nodes)
+      
+      expected = [
+        {:text, ["  before  "], []},
+        {:expression, [{:variable, ["name"], []}], [trim_right: true]},
+        {:text, ["after  "], []}
+      ]
+      
+      assert result == expected
+    end
+
+    test "trims both left and right whitespace" do
+      nodes = [
+        {:text, ["  before  "], []},
+        {:expression, [{:variable, ["name"], []}], [trim_left: true, trim_right: true]},
+        {:text, ["  after  "], []}
+      ]
+      
+      result = WhitespaceProcessor.apply_whitespace_control(nodes)
+      
+      expected = [
+        {:text, ["  before"], []},
+        {:expression, [{:variable, ["name"], []}], [trim_left: true, trim_right: true]},
+        {:text, ["after  "], []}
+      ]
+      
+      assert result == expected
+    end
+
+    test "handles multiple trim nodes in sequence" do
+      nodes = [
+        {:text, ["  start  "], []},
+        {:expression, [{:variable, ["first"], []}], [trim_left: true]},
+        {:text, ["  middle  "], []},
+        {:expression, [{:variable, ["second"], []}], [trim_right: true]},
+        {:text, ["  end  "], []}
+      ]
+      
+      result = WhitespaceProcessor.apply_whitespace_control(nodes)
+      
+      expected = [
+        {:text, ["  start"], []},
+        {:expression, [{:variable, ["first"], []}], [trim_left: true]},
+        {:text, ["  middle  "], []},
+        {:expression, [{:variable, ["second"], []}], [trim_right: true]},
+        {:text, ["end  "], []}
+      ]
+      
+      assert result == expected
+    end
+
+    test "handles tag nodes with trim options" do
+      nodes = [
+        {:text, ["  before  "], []},
+        {:tag, [:assign, "name", {:literal, ["value"], []}], [trim_left: true, trim_right: true]},
+        {:text, ["  after  "], []}
+      ]
+      
+      result = WhitespaceProcessor.apply_whitespace_control(nodes)
+      
+      expected = [
+        {:text, ["  before"], []},
+        {:tag, [:assign, "name", {:literal, ["value"], []}], [trim_left: true, trim_right: true]},
+        {:text, ["after  "], []}
+      ]
+      
+      assert result == expected
+    end
+
+    test "handles trim when no adjacent text nodes exist" do
+      nodes = [
+        {:expression, [{:variable, ["name"], []}], [trim_left: true, trim_right: true]}
+      ]
+      
+      result = WhitespaceProcessor.apply_whitespace_control(nodes)
+      
+      # Should not modify the nodes when there are no text nodes to trim
+      assert result == nodes
+    end
+
+    test "handles trim when adjacent nodes are not text nodes" do
+      nodes = [
+        {:expression, [{:variable, ["first"], []}], []},
+        {:expression, [{:variable, ["second"], []}], [trim_left: true, trim_right: true]},
+        {:expression, [{:variable, ["third"], []}], []}
+      ]
+      
+      result = WhitespaceProcessor.apply_whitespace_control(nodes)
+      
+      # Should not modify when adjacent nodes are not text nodes
+      assert result == nodes
+    end
+
+    test "handles newlines and tabs in whitespace trimming" do
+      nodes = [
+        {:text, ["  \n\t before \t\n  "], []},
+        {:expression, [{:variable, ["name"], []}], [trim_left: true, trim_right: true]},
+        {:text, ["  \n\t after \t\n  "], []}
+      ]
+      
+      result = WhitespaceProcessor.apply_whitespace_control(nodes)
+      
+      expected = [
+        {:text, ["  \n\t before"], []},
+        {:expression, [{:variable, ["name"], []}], [trim_left: true, trim_right: true]},
+        {:text, ["after \t\n  "], []}
+      ]
+      
+      assert result == expected
+    end
+
+    test "handles empty text nodes after trimming" do
+      nodes = [
+        {:text, ["   "], []},
+        {:expression, [{:variable, ["name"], []}], [trim_left: true]},
+        {:text, ["   "], []}
+      ]
+      
+      result = WhitespaceProcessor.apply_whitespace_control(nodes)
+      
+      expected = [
+        {:text, [""], []},
+        {:expression, [{:variable, ["name"], []}], [trim_left: true]},
+        {:text, ["   "], []}
+      ]
+      
+      assert result == expected
+    end
+  end
+end


### PR DESCRIPTION
Implemented comprehensive whitespace control system for the Mau template engine:

## Key Features
- Trim token parsing for expressions: `{{-`, `-}}`, `{{-` `-}}`
- Trim token parsing for tags: `{%-`, `-%}`, `{%-` `-%}`
- Left trim removes trailing whitespace from preceding text nodes
- Right trim removes leading whitespace from following text nodes
- Support for both trim removes whitespace on both sides

## Technical Implementation
- Extended parser with choice combinators for trim token detection
- Added trim_left and trim_right options to AST node structures
- Created Mau.WhitespaceProcessor module for trim logic
- Integrated whitespace processing before block processing in main pipeline
- Handles complex whitespace: newlines, tabs, multiple spaces

## Testing & Quality
- All 472 tests pass (56 doctests + 416 unit tests)
- Added 36 new tests across parser, processor, and integration
- Comprehensive coverage of all trim combinations and edge cases
- Verified compatibility with expressions, tags, conditionals, and loops

## Files Modified
- lib/mau/parser.ex - Added trim token parsing
- lib/mau/whitespace_processor.ex - New trim logic module
- lib/mau.ex - Integrated whitespace processing pipeline
- test/mau/whitespace_*_test.exs - Comprehensive test suites
- CHANGELOG.md - Documented Phase 10 features
- TASKS.md - Marked Group 10 completed

Phase 10 (Whitespace Control) completed successfully.

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Implement a comprehensive whitespace control system by extending the parser for trim tokens, adding trim options to the AST, creating Mau.WhitespaceProcessor to apply trimming logic, and integrating it into the rendering pipeline

New Features:
- Add support for whitespace trim tokens for expressions (`{{-`, `-}}`) and tags (`{%-`, `-%}`) with left, right, and both-side trimming

Enhancements:
- Introduce `trim_left` and `trim_right` options in AST node structures and extend parser with choice combinators to detect trim variants

Documentation:
- Update CHANGELOG.md to document Phase 10 features and mark Group 10 as completed in TASKS.md

Tests:
- Add parser tests for all trim token combinations, unit tests for the whitespace processor, and integration tests covering whitespace control in expressions, tags, conditionals, and loops