### PR TITLE
add flatmap directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Add `mau` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:mau, "~> 0.2.0"}
+    {:mau, "~> 0.6"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Mau.MixProject do
   def project do
     [
       app: :mau,
-      version: "0.6.0",
+      version: "0.6.1",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
## Summary by Sourcery

Add a new #flat_map directive implementation, update documentation, add tests, and bump version.

New Features:
- Introduce #flat_map directive to map over collections and flatten the results

Build:
- Bump project version to 0.6.1 and update mau dependency requirement

Documentation:
- Document the #flat_map directive in the reference guide with usage examples and update README dependency version

Tests:
- Add comprehensive tests for #flat_map covering various scenarios including nested mappings, empty or nil collections, non-list results, index access, and invalid arguments